### PR TITLE
Forward SIGTERM and SIGINT in wrapper script

### DIFF
--- a/omxplayer
+++ b/omxplayer
@@ -64,7 +64,21 @@ DBUS_SESSION_BUS_PID=`cat $OMXPLAYER_DBUS_PID`
 export DBUS_SESSION_BUS_ADDRESS
 export DBUS_SESSION_BUS_PID
 
-LD_LIBRARY_PATH="$OMXPLAYER_LIBS${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" $OMXPLAYER_BIN "$@"
+# Propagate SIGTERM and SIGINT to the player and while still allowing cleanup
+# Approach taken from http://veithen.io/2014/11/16/sigterm-propagation.html
+trap 'kill -TERM $OMXPLAYER_PID' TERM INT
+# Start omxplayer in the background, otherwise bash will ignore signals
+LD_LIBRARY_PATH="$OMXPLAYER_LIBS${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" $OMXPLAYER_BIN "$@"&
+OMXPLAYER_PID=$!
+# Wait for omxplayer to complete
+wait $OMXPLAYER_PID
+# When a signal arrives, the wait will be interrupted, but omxplayer
+# might not be terminated yet. Remove our signal handler and wait again
+# to make sure omxplayer is really terminated. When it was already
+# terminated, wait just returns the exit code.
+trap - TERM INT
+wait $OMXPLAYER_PID
+# Store the omxplayer exit code
 RESULT=$?
 
 if [ ! -z $NOREFRESH ] && [ "$NOREFRESH" == "1" ]; then


### PR DESCRIPTION
This makes sure that if the wrapper bash script receives a SIGTERM or SIGINT, that is forwarded to the actual player to terminate it. Then, the wrapper script does not terminate itself until the player does, allowing cleanup to happen as normal.

This is helpful when running omxplayer from a script that wants to terminate the player. It can just terminate the (wrapper) process that it spawned, which will terminate the script and the player, while still doing proper cleanup.

Note that SIGKILL cannot be handled in this way, since that kills the script instantly with no way to trap it.